### PR TITLE
Calculating rewards at the end of each action phase

### DIFF
--- a/ogm/occupancy_grid_map.py
+++ b/ogm/occupancy_grid_map.py
@@ -432,8 +432,8 @@ class OccupancyGridMap:
 
     return pairwise_norms
 
-  def check_final(self):
-    return ((self.final_pairwise_norms - self.curr_pairwise_norms) + 1).all()
+  def check_final(self, tol=1e-6):
+    return np.allclose(self.final_pairwise_norms, self.curr_pairwise_norms, atol=tol)
 
   # need to calculate edges first
   def calculate_edges(self, modules, module_positions):

--- a/ogm/ogm_env.py
+++ b/ogm/ogm_env.py
@@ -10,49 +10,69 @@ class OGMEnv:
     def __init__(self, step_cost = -0.01, max_steps = None):
         self.step_cost = step_cost
         self.max_steps = max_steps 
-        self.steps_token = 0
-        self.ogm = OccupancyGridMap
+        self.steps_taken = 0
+        self.ogm = None
+        self.action_buffer = [] 
+        self.action_count = 0 
+        self.num_modules = None
+        self.initial_norm_diff = None 
 
     def reset(self, initial_config, final_config):
         self.ogm = OccupancyGridMap(initial_config, final_config, len(initial_config))
         self.steps_taken = 0
+        self.action_buffer = []
+        self.action_count = 0
+        self.num_modules = len(initial_config)
+        self.initial_norm_diff = np.linalg.norm(
+            self.ogm.final_pairwise_norms - self.ogm.curr_pairwise_norms, 'fro'
+        )
         return self.get_observation()
     
     def step(self, action):
         if self.ogm is None:
             raise Exception("Environment not set. call reset function")
 
-        module, pivot = action
+        self.action_buffer.append(action)
+        self.action_count += 1
 
-        # 1. Calculate distance before the move
-        initial_distance = np.sum(self.ogm.curr_grid_map != self.ogm.final_grid_map)
+        reward = 0.0
+        done = False
+        observation = self.get_observation()
+        info = {'step': self.steps_taken}
 
-        # Execute the action
-        is_valid_action = self.ogm.calc_possible_actions()[module][pivot-1]
-        
-        if is_valid_action:
-            self.ogm.take_action(module, pivot)
-        
+        # Return 0 reward if not all modules have acted
+        if self.action_count < self.num_modules:
+            return observation, reward, done, info
+
         self.steps_taken += 1
+        invalid_move = False
 
-        # 2. Check for success and calculate new distance
-        done = self.ogm.check_final()
-        final_distance = np.sum(self.ogm.curr_grid_map != self.ogm.final_grid_map)
+        # Execute buffered actions
+        for module, pivot in self.action_buffer:
+            is_valid_action = self.ogm.calc_possible_actions()[module][pivot-1]
+            if is_valid_action:
+                self.ogm.take_action(module, pivot)
+            else:
+                invalid_move = True
 
-        # 3. Calculate the hybrid reward
-        potential_reward = initial_distance - final_distance 
-        
-        # Large bonus for completing the puzzle
-        success_bonus = 100.0 if done else 0.0
-        
-        # Small penalty for invalid moves to discourage them
-        invalid_move_penalty = -1.0 if not is_valid_action else 0.0
+        final_norm_diff = np.linalg.norm(
+            self.ogm.final_pairwise_norms - self.ogm.curr_pairwise_norms, 'fro'
+        )
 
-        # Combine the components into the final reward for this step
+        # Calculate reward
+        # the Frobenius norm scales with n^2 (for n modules). This could result in large reward values for large n
+        # so normalizing the norm difference by n^2 keeps rewards in a reasonable range
+        potential_reward = (self.initial_norm_diff - final_norm_diff) / (self.num_modules ** 2)
+        success_bonus = 100.0 if self.ogm.check_final() else 0.0
+        invalid_move_penalty = -1.0 if invalid_move else 0.0
         reward = potential_reward + success_bonus + invalid_move_penalty + self.step_cost
 
-        if self.max_steps is not None and self.steps_taken >= self.max_steps:
-            done = True
+        self.initial_norm_diff = final_norm_diff
+
+        done = self.ogm.check_final() or (self.max_steps is not None and self.steps_taken >= self.max_steps)
+
+        self.action_buffer = []
+        self.action_count = 0
 
         observation = self.get_observation()
         info = {'step': self.steps_taken}

--- a/train/train_mappo.py
+++ b/train/train_mappo.py
@@ -66,27 +66,25 @@ def train(args):
         while not done and step < args.max_steps:
             random_queue = env.ogm.calc_queue()
             env.ogm.calc_pre_action_grid_map()
+            phase_reward = 0.0
 
-            for aid in random_queue:#range(0, args.num_agents):
+            for aid in random_queue:
                 aid = aid - 1
                 mask = env.ogm.calc_possible_actions()[aid + 1]
-                
-                # Store the current state before it gets overwritten 
                 current_obs = obs
-                
                 action, log_prob = agent.select_action(current_obs, aid, mask=mask)
-                # action, log_prob = agent.select_action(obs, aid)
                 obs, reward, done, _ = env.step((aid+1, action+1))
-                
-                # Pass the state that was used for the decision to the buffer
                 agent.store(current_obs, aid, action, log_prob, reward, done, mask)
-                
-                episode_reward += reward
-                step+=1
-                if visualizer:
-                    visualizer.capture_state()
-                if done or step >= args.max_steps:
+                phase_reward = reward
+                if done or step >= args.max_steps: 
                     break
+
+            episode_reward += phase_reward
+            step += 1 
+            if visualizer:
+                visualizer.capture_state()
+            if done or step >= args.max_steps:
+                break
 
         # Capture final state after episode ends
         if visualizer:


### PR DESCRIPTION
fixes #68 
- Calculates reward at the end of each action phase
- uses the pairwise norms as discussed
- changed `check_final()`method in `occupancy_grid_map.py` to use `np.allclose` with a tolerance of `1e-6`, as earlier it was giving `True` for all the steps as it only checked non zero values in the matrix